### PR TITLE
fix: remove unnecessary next-sitemap postbuild script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "type-check": "tsc --noEmit",
-    "build:analyze": "ANALYZE=true npm run build",
-    "postbuild": "next-sitemap"
+    "build:analyze": "ANALYZE=true npm run build"
   },
   "dependencies": {
     "@google/generative-ai": "^0.21.0",


### PR DESCRIPTION
- Remove postbuild script that references non-existent next-sitemap package
- Project already uses Next.js 15 built-in sitemap.ts for sitemap generation
- Fixes build error: 'next-sitemap: command not found'

🤖 Generated with [Claude Code](https://claude.ai/code)